### PR TITLE
Tumblr plugin raise an error when triggering a new generation.

### DIFF
--- a/src/tumblr.plugin.coffee
+++ b/src/tumblr.plugin.coffee
@@ -200,11 +200,11 @@ module.exports = (BasePlugin) ->
 							return complete(err)  if err
 
 							# Log
-							if document
+							if document?
 								++imported
 								docpad.log('debug', "Imported  tumblr post #{i}/#{tumblrPosts.length}: #{document.getFilePath()}")
 							else
-								docpad.log('debug', "Skipped   tumblr post #{i}/#{tumblrPosts.length}: #{document.getFilePath()}")
+								docpad.log('debug', "Skipped   tumblr post #{i}/#{tumblrPosts.length}")
 
 							# Complete
 							return complete()


### PR DESCRIPTION
when creating the post if the document already exist then null is returned.
In this case we can not call `getFilePath()` on a `null` object.
